### PR TITLE
Added routes for new devices.

### DIFF
--- a/routes/api.rb
+++ b/routes/api.rb
@@ -434,5 +434,12 @@ module Optopus
       end
     end
 
+    get '/api/device/:serial' do
+      @device = Optopus::Device.where(:serial_number => params[:serial].downcase).to_json
+    end
+
+    get '/api/device/:serial/new' do
+      @device = Optopus::Device.where(:serial_number => params[:serial].downcase, :provisioned => false).to_json
+    end
   end
 end


### PR DESCRIPTION
Added two new routes:
- get '/api/device/:serial' do
  Get all device information for a given serial number.
- get '/api/device/:serial/new' do
  Get unprovisioned information only for a given serial number.
